### PR TITLE
Maybe Class

### DIFF
--- a/Monads/Interfaces.ts
+++ b/Monads/Interfaces.ts
@@ -1,0 +1,10 @@
+export namespace MonadDefinitions{
+    export interface Monad<Value>{
+        map<A>(fn:(value:Value) => A): Monad<A>
+    }
+    
+    export interface Applicative<Value>{
+        map<A>(fn:(value:Value) => A): Applicative<A>
+        ap<A, B>(this: Applicative<(value:A) => B>, otherApplicative: Applicative<A>): Applicative<B>
+    }
+}

--- a/Monads/Maybe.ts
+++ b/Monads/Maybe.ts
@@ -1,0 +1,59 @@
+//https://spin.atomicobject.com/2018/01/15/typescript-flexible-nominal-typing/
+
+import { MonadDefinitions } from "./Interfaces"
+interface Monad<Value> extends MonadDefinitions.Monad<Value>{
+}
+interface Applicative<Value> extends MonadDefinitions.Applicative<Value>{
+}
+
+export class Maybe<Value> implements Applicative<Value>{
+    $value?:Value | null
+
+    constructor(value: Value){
+        this.$value = value
+    }
+
+    static of<A>(x:A):Maybe<A>{
+        return new Maybe(x)
+    }
+
+    isNothing():Boolean{
+        return this.$value == null || this.$value == undefined
+    }
+
+    // typecasting 
+    // https://www.typescripttutorial.net/typescript-tutorial/type-casting/
+    map<B>(fn:(value:Value) => B): Maybe<B> {
+        return this.isNothing() ? this as Maybe<null> : Maybe.of(fn(this.$value))
+    }
+
+    // specifying the type of 'this'
+    // https://www.typescriptlang.org/docs/handbook/2/functions.html
+    // https://stackoverflow.com/questions/28920753/declaring-the-type-of-this-in-a-typescript-function
+    join<A>(this:Maybe<Maybe<A>>): Maybe<A>{
+        return this.isNothing() ? this as Maybe<null> : Maybe.of(this.$value.$value)
+        // return this.isNothing() ? this : this.$value
+    }
+    flatmap<A>(fn:(value:Value) => Maybe<A>): Maybe<A>{
+        return this.map(fn).join()
+    }
+    filter(fn:(value:Value) => Boolean): Maybe<Value>{
+        return this.isNothing() ? this as Maybe<null> : fn(this.$value) ? this as Maybe<Value> : Maybe.of(null)
+    }
+    ap<A, B>(this:Maybe<(value:A) => B>, otherMaybe:Maybe<A>): Maybe<B>{
+        return this.isNothing() ? this as Maybe<null> : otherMaybe.map(this.$value)
+    }
+
+    traverse<A, B extends Monad<A>, C extends Monad<Maybe<A>>> (fn: (value: Value) => B, of: (value: Maybe<A>) => C): C{
+        return this.isNothing() ? of(this as Maybe<null>) : fn(this.$value).map(Maybe.of) as C
+    }
+
+
+    identity<A>(x:A):A{
+        return x
+    }
+
+    sequence<A, B extends Monad<Maybe<A>>>(this: Maybe<Monad<A>>, of: (value: Maybe<A>) => B ){
+        return this.traverse(this.identity, of)
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "monads",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "typescript": "^4.9.4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "typescript": "^4.9.4"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+      "lib": ["esnext"],
+      "experimentalDecorators": true
+    }
+  }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-      "lib": ["esnext"],
+      "target": "ES5",
       "experimentalDecorators": true
     }
   }


### PR DESCRIPTION
We created a maybe class and used a decorator function to handle null checks for the class methods. Using decorators seems to have two advantages: 

1. Decorators help simplify the typescript. For example, we do not have to account for the Maybe<null> in our return type as it is implied by our using the Maybe in the first place (i.e. You would use Maybe is just in case the value inside is null. We do not need the compiler to tell us that the value might be null.) This means our code can use fewer [type assertions])(https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#type-assertions) and be easier to read.
2. Decorators help reduce the number of times we need to type "this.isNothing() ? this : someOtherValue", (i.e. boilerplate). This means our code is less prone to errors and should be easier reason about.
